### PR TITLE
Added regression test for a bug raised in Stack Overflow question 37711933

### DIFF
--- a/regressions/smt2/sine9.expected.out
+++ b/regressions/smt2/sine9.expected.out
@@ -1,0 +1,1 @@
+unknown

--- a/regressions/smt2/sine9.smt2
+++ b/regressions/smt2/sine9.smt2
@@ -1,0 +1,8 @@
+;; Copyright (c) 2016 Microsoft Corporation 
+
+(set-info :source |Written by D. B. Staple for Stack Overflow question 37711933.|)
+(set-info :status unknown)
+
+(declare-fun x () Real)
+(assert (< (sin x) -1.0))
+(check-sat)


### PR DESCRIPTION
This is based on [a Stack Overflow question](https://stackoverflow.com/questions/37711933/undocumented-trigonometric-functions-in-z3-reparable).  This .smt2 file would cause a seg fault with Z3 4.4.1, or cause ballooning memory usage (tens of gigs in a few seconds) until it was fixed by Nikolaj Bjorner yesterday.  As of cb29c07 this test passes fine.
