### PR TITLE
Change isAlive to is_alive to support Python 3.9

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -237,7 +237,7 @@ def timeout(func, args=(), kwargs={}, timeout_duration=1.0, default=None):
     it.join(timeout_duration)
     if it.exception is not None:
         raise it.exception
-    if it.isAlive():
+    if it.is_alive():
         return default
     else:
         return it.result


### PR DESCRIPTION
The `isAlive()` method of `threading.Thread` [has been removed in Python 3.9](https://docs.python.org/3.9/whatsnew/3.9.html#removed).
Running Z3Test raises an exception:

```
AttributeError: 'InterruptableThread' object has no attribute 'isAlive'
```