### PR TITLE
Update coverage test timeout

### DIFF
--- a/scripts/test_coverage_tests.py
+++ b/scripts/test_coverage_tests.py
@@ -1,5 +1,5 @@
 from util import *
 import sys
 # Usage: z3-install-dir benchmark-dir
-test_cpp(sys.argv[1], sys.argv[2], timeout_duration=60.0)
+test_cpp(sys.argv[1], sys.argv[2], timeout_duration=1800.0)
 exit(0)


### PR DESCRIPTION
Due to a recently added coverage test, the pipeline was timing out. This commit updates the individual test timeout to a more generous 30 minute per test, to fix the current timeout issue.

A better option would be defining a per-test timeout value.