### PR TITLE
Add regressions for proven-unbounded objectives (nlsat optimizer)

### DIFF
--- a/regressions/smt2/opt_nlsat_unbounded_above.expected.out
+++ b/regressions/smt2/opt_nlsat_unbounded_above.expected.out
@@ -1,0 +1,4 @@
+sat
+(objectives
+ (x oo)
+)

--- a/regressions/smt2/opt_nlsat_unbounded_above.smt2
+++ b/regressions/smt2/opt_nlsat_unbounded_above.smt2
@@ -1,0 +1,11 @@
+; maximize x s.t. x*y = 1 /\ y > 0: x is unbounded above, but no single bound
+; x >= c is ever refuted, so the climb alone cannot terminate. After a streak
+; of climb rounds the optimizer proves unboundedness with one quantified
+; (nlqsat) query and reports oo.
+(declare-const x Real)
+(declare-const y Real)
+(assert (= (* x y) 1.0))
+(assert (> y 0.0))
+(maximize x)
+(check-sat)
+(get-objectives)

--- a/regressions/smt2/opt_nlsat_unbounded_below.expected.out
+++ b/regressions/smt2/opt_nlsat_unbounded_below.expected.out
@@ -1,0 +1,4 @@
+sat
+(objectives
+ (x (* (- 1) oo))
+)

--- a/regressions/smt2/opt_nlsat_unbounded_below.smt2
+++ b/regressions/smt2/opt_nlsat_unbounded_below.smt2
@@ -1,0 +1,7 @@
+; minimize x s.t. x^2 >= 4, i.e. x <= -2 or x >= 2: unbounded below. Exercises
+; the same unboundedness proof through objective negation and reports -oo.
+(declare-const x Real)
+(assert (>= (* x x) 4.0))
+(minimize x)
+(check-sat)
+(get-objectives)

--- a/regressions/smt2/opt_nlsat_unbounded_box.expected.out
+++ b/regressions/smt2/opt_nlsat_unbounded_box.expected.out
@@ -1,0 +1,5 @@
+sat
+(objectives
+ (x oo)
+ (y (root-obj (+ (^ x 2) (- 2)) 2))
+)

--- a/regressions/smt2/opt_nlsat_unbounded_box.smt2
+++ b/regressions/smt2/opt_nlsat_unbounded_box.smt2
@@ -1,0 +1,12 @@
+; box: one objective unbounded above (x^2 >= 4 leaves x >= 2 feasible for any
+; bound) proven oo by the quantified query, the other attained at the
+; irrational optimum sqrt(2) reported as a root-obj.
+(set-option :opt.priority box)
+(declare-const x Real)
+(declare-const y Real)
+(assert (>= (* x x) 4.0))
+(assert (<= (* y y) 2.0))
+(maximize x)
+(maximize y)
+(check-sat)
+(get-objectives)


### PR DESCRIPTION
End-to-end regressions for Z3Prover/z3#10718, which proves unboundedness of real objectives over nonlinear constraints with one quantified nlsat query:

- `opt_nlsat_unbounded_above`: maximize x under x*y = 1 and y > 0 — no bound x >= c is ever refuted, so the climb alone cannot terminate; expects `(x oo)`.
- `opt_nlsat_unbounded_below`: minimize x under x^2 >= 4 — the same proof through objective negation; expects `(x (* (- 1) oo))`.
- `opt_nlsat_unbounded_box`: box combinator mixing an unbounded objective with one attained at the irrational optimum sqrt(2), reported as a root-obj.

All three finish in well under a second. They require Z3Prover/z3#10718 and should be merged after it; on current master the first two time out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)