### PR TITLE
Add regression for an objective pinned to an algebraic value by an equation

### DIFF
--- a/regressions/smt2/opt_nlsat_pinned_by_equation.expected.out
+++ b/regressions/smt2/opt_nlsat_pinned_by_equation.expected.out
@@ -1,0 +1,4 @@
+sat
+(objectives
+ (y (root-obj (+ (* 2 (^ x 2)) (- 1)) 2))
+)

--- a/regressions/smt2/opt_nlsat_pinned_by_equation.smt2
+++ b/regressions/smt2/opt_nlsat_pinned_by_equation.smt2
@@ -1,0 +1,15 @@
+; maximize y s.t. x^2 = 2 /\ x >= 1 /\ x*y = 1: the objective is pinned to the
+; single algebraic value y = 1/sqrt(2). The model value of the objective is an
+; irrational algebraic number, which used to be dropped when updating the
+; objective floor (only rational numerals were accepted), so the optimizer
+; reported -oo for this satisfiable objective. The floor now uses a rational
+; lower bound of the algebraic value and the nlsat fallback recovers the
+; exact optimum.
+(declare-const x Real)
+(declare-const y Real)
+(assert (= (* x x) 2.0))
+(assert (>= x 1.0))
+(assert (= (* x y) 1.0))
+(maximize y)
+(check-sat)
+(get-objectives)


### PR DESCRIPTION
maximize y under x^2 = 2, x >= 1, x*y = 1 used to answer `sat` with y = -oo: the objective's algebraic model value 1/sqrt(2) was dropped by opt_solver's rational-only objective-floor update. Fixed in Z3Prover/z3#10723; the expected answer is the exact `(root-obj (+ (* 2 (^ x 2)) (- 1)) 2)`.

Merge after Z3Prover/z3#10723 — the test reports -oo (and fails) on builds without that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)